### PR TITLE
Fix the calculation for max practice sessions available

### DIFF
--- a/static/js/character.js
+++ b/static/js/character.js
@@ -117,21 +117,38 @@ export class Character {
   }
 
   calculateMaxPracs(race) {
-    let pracs;
-    if (this.faction === 'Freefolk' || race === 'Númenórean') {
-      if (this.level <= 25) {
-        pracs = 11 * this.level;
-      } else {
-        pracs = (11 * 25) + Math.floor((this.level - 25) / 1.42);
-      }
-    } else {
-      if (this.level <= 25) {
-        pracs = 10 * this.level;
-      } else {
-        pracs = (10 * 25) + Math.floor((this.level - 25) / 1.7);
-      }
+    let basePracsPerLevel;
+    let bonusPracs = 0;
+
+    // Determine base practice sessions per level based on race
+    switch (race) {
+        case 'Freefolk':
+        case 'Númenórean':
+            basePracsPerLevel = 10;
+            bonusPracs = 2; // Starting bonus
+            break;
+        case 'Orc':
+            basePracsPerLevel = 9;
+            bonusPracs = 1; // Starting bonus
+            break;
+        case 'Troll':
+            basePracsPerLevel = 6;
+            bonusPracs = 0; // No starting bonus
+            break;
     }
 
+    // Calculate real level (see Mume news post 2478)
+    let realLevel;
+    if (this.level <= 25) {
+        realLevel = this.level * 1.1; // 110% of a level
+    } else {
+        realLevel = (25 * 1.1) + ((this.level - 25) * 0.0667); // 6.67% per level after 25
+    }
+
+    // Calculate total practice sessions with standard rounding
+    let pracs = Math.round(realLevel * basePracsPerLevel) + bonusPracs;
+
+    // Apply Eriadorian subrace bonus
     if (this.subrace == 'Eriadorian') {
       pracs += 5;
     }


### PR DESCRIPTION
I have done some digging and testing and am confident that this is how practices are calculated (I have not tested BNs or Zaugurz, but this seems right for all the other races, and should be right for those as well).

Each race gets a fixed number of practice sessions for each level:
```
- Freefolk/BNs	10 pracs/level
- Orcs		 9 pracs/level
- Trolls	 6 pracs/level
```

	
Each race (except trolls) gets bonus practice sessions at the start of their journey:
```
- Pukes/BNs	 2 pracs
- Orcs		 1 prac
```

	
Eriadorian men get an additional subrace bonus:

`- Eriadorian	 5 subraces pracs`

The above is based on the 'real' level of the character versus the level that is shown to the player, which is calculated as described in news 2478:

	at level 1-25 you now get 110% of a level, and at level 26-100 you get  6.67% of a level.

The updated code should correctly calculate max pracs based on the above logic.